### PR TITLE
추론 서버 분리 및 서비스 서버 수정 및 rag 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,31 @@
 # Coffit 서버
 ## How to run
 - 할당받은 rebellions 자원 ssh로 접속
-- `$ cd malhaedgh/malhaedgh_backend`
-- `$ uvicorn main:app --host 0.0.0.0 --port 8000 --reload`
+-  `$ cd malhaedgh/malhaedgh_backend`
+-  
+- ```bash 
+    $ python3 -m vllm.entrypoints.openai.api_server \
+        --model rbln_vllm_llama-3-Korean-Bllossom-8B_npu4_batch4_max4096 \
+        --compiled-model-dir rbln_vllm_llama-3-Korean-Bllossom-8B_npu4_batch4_max4096 \
+        --dtype auto \
+        --device rbln \
+        --max-num-seqs 4 \
+        --max-num-batched-tokens 4096 \
+        --max-model-len 4096 \
+        --block-size 4096 \
+        --api-key 1234 
+    ``` 
+    추론서버(vLLM) 실행
+ 
+- `$ streamlit run ChatServer.py` streamlit 채팅 서버 실행
+- `$ uvicorn main:app --host 0.0.0.0 --port 9000 --reload` fastapi 서비스 서버 실행
 
 - POSTMAN으로 결과 확인 가능
 
 
 ## Wikis
 - [파일 설명](https://github.com/marhaedgh/rbln-infer-server/wiki/%ED%8C%8C%EC%9D%BC-%EC%84%A4%EB%AA%85)
-- [Triton Inference Server 실행하는 법](https://github.com/marhaedgh/rbln-infer-server/wiki/Triton-Inference-Server-%EC%8B%A4%ED%96%89%ED%95%98%EB%8A%94-%EB%B2%95)
+- ~~[Triton Inference Server 실행하는 법](https://github.com/marhaedgh/rbln-infer-server/wiki/Triton-Inference-Server-%EC%8B%A4%ED%96%89%ED%95%98%EB%8A%94-%EB%B2%95)~~
 - [Basic vLLM backend Test](https://github.com/marhaedgh/rbln-infer-server/wiki/Basic-vLLM-backend-Test)
 - [docker -> mysql](https://github.com/marhaedgh/rbln-infer-server/wiki/docker-%E2%80%90--mysql-%EC%8B%A4%ED%96%89)
 

--- a/marhaedgh_backend/ChatServer.py
+++ b/marhaedgh_backend/ChatServer.py
@@ -6,7 +6,7 @@ import json
 from db.database import get_db
 from repository.NotificationRepository import NotificationRepository
 
-VLLM_API_URL = "http://localhost:8000/api/v1/chat-infer"
+VLLM_API_URL = "http://localhost:9000/api/v1/chat-infer"
 
 with st.chat_message("user"):
     st.write("안녕하세요! Coffit AI 에요, 무엇이든 물어보세요! 👋")
@@ -64,12 +64,14 @@ if prompt := st.chat_input("궁금한 점을 질문해 주세요!"):
         )
         
         # 서버에서 받은 스트리밍 응답 출력
+
         full_response = ""
         for chunk in response.iter_lines():
             if chunk:
                 decoded_chunk = chunk.decode("utf-8")
                 full_response += decoded_chunk
                 placeholder.markdown(full_response)
+
         
         # assistant의 응답을 세션에 추가
         st.session_state.messages.append({"role": "assistant", "content": full_response})

--- a/marhaedgh_backend/controller/InferenceController.py
+++ b/marhaedgh_backend/controller/InferenceController.py
@@ -8,6 +8,22 @@ from dto.InferRequest import InferRequest
 from dto.DemonInferRequest import DemonInferRequest
 
 import ModelLoader
+
+
+from llama_index.core import Settings
+from util.RBLNBGEM3Embeddings import RBLNBGEM3Embeddings
+from llama_index.llms.openai_like import OpenAILike
+
+
+Settings.embed_model = RBLNBGEM3Embeddings()
+Settings.llm = OpenAILike(
+    model="rbln_vllm_llama-3-Korean-Bllossom-8B_npu4_batch4_max4096",
+    api_base="http://0.0.0.0:8000/v1",
+    api_key="1234",
+    max_tokens=1024,
+    is_chat_model=True
+)
+
  
 inferenceService = InferenceService(ModelLoader.InferenceModel())
 agentService = AgentService(ModelLoader.InferenceModel())
@@ -39,4 +55,4 @@ async def inference_chatting_request(infer_request: Request):
     messages = data["messages"]
     
     # 스트리밍 방식으로 응답 전송
-    return StreamingResponse(inferenceService.inference_chatting_streaming(messages), media_type="text/plain")
+    return StreamingResponse(await inferenceService.inference_chatting_streaming(messages), media_type="text/plain")

--- a/marhaedgh_backend/main.py
+++ b/marhaedgh_backend/main.py
@@ -5,7 +5,6 @@ from controller import InferenceController, UserController, NotificationControll
 
 from service.AgentService import AgentService
 
-import ModelLoader
 
 SWAGGER_HEADERS = {
     "title": "말해다규현 api 서버 테스트",

--- a/marhaedgh_backend/service/AgentService.py
+++ b/marhaedgh_backend/service/AgentService.py
@@ -4,6 +4,8 @@ from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
 from langchain.text_splitter import CharacterTextSplitter
 from sqlalchemy.orm import Session
 
+from llama_index.core import Settings
+
 from dto.DemonInferResponse import DemonInferResponse
 from db.database import get_db
 from repository.BusinessDataRepository import BusinessDataRepository
@@ -34,46 +36,29 @@ class AgentService:
     async def demon_alert_response_efficient(self, url):
         #URL 타고 들어가서 본문내용(PDF) 추출 후 텍스트로 변환 //일단 html스크랩
 
-        output_dir = "./rag_data"  # 저장할 디렉토리 경로
-        # URL에서 텍스트 추출 및 저장
+        output_dir = "./rag_data/data"
+
         content = extract_text_from_url(url, output_dir)
 
-        # 배치로 요청을 처리합니다.
-        sampling_params = SamplingParams(
-            temperature=0.0,
-            skip_special_tokens=True,
-            stop_token_ids=self.modelLoader.stop_tokens(),
-        )
 
-        # 각 추론 요청에 필요한 JSON 파일을 로드하고 메시지를 생성합니다.
-        layer0_tasks = [
-            await self.prepare_request(content, "./prompt/title.json"),                   #제목
-            await self.prepare_request(content, "./prompt/keywords.json"),                #키워드
-            await self.prepare_request(content, "./prompt/summarization_korean.json"),    #요약
-            await self.prepare_request(content, "./prompt/classification.json"),          #분류
-            await self.prepare_request(content, "./prompt/whattodo.json"),                #할일
-        ]
+        layer0_title = Settings.llm.complete(await self.prepare_request(content, "./prompt/title.json"))
+        layer0_keywords = Settings.llm.complete(await self.prepare_request(content, "./prompt/keywords.json"))
+        layer0_summarization = Settings.llm.complete(await self.prepare_request(content, "./prompt/summarization_korean.json"))
+        layer0_classification = Settings.llm.complete(await self.prepare_request(content, "./prompt/classification.json"))
+        layer0_whattodo = Settings.llm.complete(await self.prepare_request(content, "./prompt/whattodo.json"))
 
-        layer0_results = await self.modelLoader.run_multi(layer0_tasks, sampling_params)
 
-        layer1_tasks = [
-            await self.prepare_request(
-                layer0_results[2].outputs[0].text,
-                "./prompt/line_summarization.json"                               #요약 -> 한줄요약
-            )
-        ]
+        layer1_line_summarization = Settings.llm.complete(await self.prepare_request(content, "./prompt/line_summarization.json"))
 
-        layer1_results = await self.modelLoader.run_multi(layer1_tasks, sampling_params)
 
-        # 여기서 레이어링 / 멀티 단위로 해서 더 빠르게 처리
+        title = str(layer0_title)
+        keyword = str(layer0_keywords)
+        line_summarization = str(layer1_line_summarization)
+        summarization = str(layer0_summarization)
+        classification = str(layer0_classification)
+        whattodo = str(layer0_whattodo)
 
-        title = layer0_results[0].outputs[0].text
-        keyword = layer0_results[1].outputs[0].text
-        summarizations = [layer0_results[2].outputs[0].text, layer1_results[0].outputs[0].text]
-        classification = layer0_results[3].outputs[0].text
-        whattodo = layer0_results[4].outputs[0].text
 
-        # 데이터베이스에 저장
         db: Session = next(get_db())
         business_data_repository = BusinessDataRepository(db)
         business_data_id = 0  # 예시값
@@ -83,8 +68,8 @@ class AgentService:
             "business_data_id": business_data_id,
             "title": title,
             "keywords": json.dumps({"keywords": keyword}),
-            "line_summarization": summarizations[1],
-            "text_summarization": summarizations[0],
+            "line_summarization": line_summarization,
+            "text_summarization": summarization,
             "task_summarization": whattodo
         })
 
@@ -94,14 +79,16 @@ class AgentService:
             "alert_id": gen_alert.id
         })
 
+
         demon_infer_response = DemonInferResponse(
             title=title, 
             keywords=keyword,
-            line_summarization=summarizations[1],
-            summarization=summarizations[0],
+            line_summarization=line_summarization,
+            summarization=summarization,
             classification=classification,
             what_to_do=whattodo
         )
+
 
         return demon_infer_response
         


### PR DESCRIPTION
- vllm 추론서버 openAI 인터페이스로 분리
- agentService demon infer 추론서버로 요청 보내게끔 수정
- inferenceService infer 추론서버로 요청 보내게끔 수정
- inferenceService chatting infer Rag한 뒤 추론서버로 요청 보내게끔 수정 
- resolve #19 

- streamlit 채팅 서버 rag 적용
- streamlit chat -> fastapi, rag agent -> 추론서버 형태로 지나감
- resolve #20 